### PR TITLE
tap: fix radiotap TSFT 8-byte alignment (fixes wholesale frame drops on EXT radiotap)

### DIFF
--- a/tap/src/protocols/parsers/dot11/dot11_header_parser.rs
+++ b/tap/src/protocols/parsers/dot11/dot11_header_parser.rs
@@ -46,6 +46,8 @@ pub fn parse(data: &Arc<Dot11RawFrame>) -> Result<(Dot11Frame, u32), Error> {
 
     // TSFT.
     if present_flags.tsft {
+        // Radiotap spec: TSFT must be 8-byte aligned.
+        radiotap_buffer.align(8);
         // not parsing
         let _ = match radiotap_buffer.take(8) {
             Some(a) => a,


### PR DESCRIPTION
Fixes #1498

## What

Add the radiotap-spec-required **8-byte alignment before the TSFT field** in `tap/src/protocols/parsers/dot11/dot11_header_parser.rs`. When the present-flags word carries the EXT bit (e.g. `ath9k_htc` emits two present words), the field area starts at a 4-byte-misaligned offset; without the alignment, the channel field is read 4 bytes early and lands on `0x0000`, tripping the `frequency == 0` bail — discarding **every** frame.

## Why

See #1498 for full detail. Symptom: a tap only ever records the single strongest AP while raw `tcpdump` on the same interface sees dozens; deauth/disconnect timeline events never fire because frames never make it past the header parser.

## Verification

Tested with a USB Atheros AR9271 (`ath9k_htc`) tap on Ubuntu, pinned channel:

| | before | after |
|---|---|---|
| "bad reported frequency" failures / 30 s | 6,783 | 0 |
| beacons parsed / 30 s | 0 | 1,744 |
| distinct BSSIDs recorded (5 min) | 2 (hours) | 42+ |