### PR TITLE
tap: derive dot11 fingerprints from beacon frames only

### DIFF
--- a/tap/src/state/tables/dot11_table.rs
+++ b/tap/src/state/tables/dot11_table.rs
@@ -163,7 +163,12 @@ impl Dot11Table {
                                             ssid.wps.push(has_wps);
                                         }
 
-                                        if !ssid.fingerprints.contains(&fingerprint) {
+                                        // Fingerprints are derived from beacon frames only.
+                                        // Probe responses may legitimately carry reduced element
+                                        // sets (trimmed rates, missing HT/HE elements, etc.), which
+                                        // would otherwise create spurious fingerprint variants
+                                        // and false "unexpected fingerprint" alerts.
+                                        if frame_type == FrameSubType::Beacon && !ssid.fingerprints.contains(&fingerprint) {
                                             ssid.fingerprints.push(fingerprint.clone());
                                         }
 


### PR DESCRIPTION
## Problem

`register_advertisement` merges fingerprints from both beacon and probe-response frames into the SSID report. Probe responses may legitimately carry reduced element sets (trimmed supported/extended rates, missing HT/HE elements, no RSN in some softAP responses), so an otherwise stable AP produces spurious fingerprint variants.

The node (`Dot11Table.java`) alerts on any observed fingerprint not in the approved set, so monitored networks fire DOT11_MONITOR_FINGERPRINT alerts for their own AP's frames, with a distinct hash per alert (see #1506 for production data: stable beacon fingerprint across 27,965 sightings, variant fingerprints from probe-response frames).

## Fix

Only beacon frames contribute fingerprints to the SSID report. A network's fingerprint should mean *what its beacons look like*; probe responses are session-oriented and legitimately differ.

## Testing

Deployed on a self-hosted tap: variant fingerprints stopped appearing for the monitored network; beacon fingerprint remains stable.

Fixes #1506
