### PR TITLE
tap: stable dot11 fingerprints (parse- and subtype-independent)

### DIFF
--- a/tap/src/protocols/parsers/dot11/management/advertising_frame_parser_tools.rs
+++ b/tap/src/protocols/parsers/dot11/management/advertising_frame_parser_tools.rs
@@ -95,13 +95,32 @@ pub fn parse_tagged_parameters(payload: &[u8],
 
             let data = &payload[cursor..cursor+length];
             cursor += length;
+            debug!("[IE] cursor_before={} number={} len={} data={:02x?} bssid={}", cursor-length-2, number, length, &data[..data.len().min(20)], bssid);
 
             match number {
                 0 => {
-                    // SSID.
-                    let ssid_s = String::from_utf8_lossy(data).to_string();
-                    if !ssid_s.trim().is_empty() {
-                        ssid = Option::Some(ssid_s);
+                    // SSID. Keep valid UTF-8 as-is; escape invalid bytes
+                    // Wireshark-style (\\xHH) so the raw bytes stay lossless.
+                    match String::from_utf8(data.to_vec()) {
+                        Ok(s) => {
+                            let s = s.trim().to_string();
+                            if !s.is_empty() {
+                                ssid = Option::Some(s);
+                            }
+                        }
+                        Err(_) => {
+                            let escaped: String = data.iter().map(|b| {
+                                if (0x20..=0x7e).contains(b) {
+                                    (*b as char).to_string()
+                                } else {
+                                    format!("\\x{:02x}", b)
+                                }
+                            }).collect();
+                            let s = escaped.trim().to_string();
+                            if !s.is_empty() {
+                                ssid = Option::Some(s);
+                            }
+                        }
                     }
                 },
                 1 => {
@@ -123,6 +142,14 @@ pub fn parse_tagged_parameters(payload: &[u8],
                 },
                 48 => {
                     // RSN. (WPA 2/3)
+                    // The RAW RSN element bytes always contribute to the fingerprint,
+                    // regardless of parse success. A parse hiccup on a single frame
+                    // (truncated element, unknown suite, PMF quirk) must not change the
+                    // fingerprint hash, otherwise the same AP alternates between two
+                    // fingerprints and monitored networks fire spurious
+                    // "unexpected fingerprint" alerts.
+                    security_bytes.extend(data);
+
                     let suites: CipherSuites = match parse_wpa_security(data) {
                         Ok(suites) => suites,
                         Err(e) => {
@@ -147,7 +174,6 @@ pub fn parse_tagged_parameters(payload: &[u8],
                     let protocols = vec![decide_wpa_identifier(&suites, &pmf).unwrap()];
 
                     security.push(SecurityInformation {protocols, pmf, suites: Option::Some(suites)});
-                    security_bytes.extend(data);
                 }
                 50 => {
                     // Extended supported rates.
@@ -323,6 +349,7 @@ fn parse_wpa_security(data: &[u8]) -> Result<CipherSuites, Error> {
     }
 
     if LittleEndian::read_u16(&data[0..2]) != 1 {
+        debug!("[DBG] RSN bad data={:02x?} len={}", &data[..data.len().min(20)], data.len());
         bail!("Unsupported RSN/WPA version <{:?}>.", &data)
     }
 

--- a/tap/src/protocols/parsers/dot11/management/advertising_frame_parser_tools.rs
+++ b/tap/src/protocols/parsers/dot11/management/advertising_frame_parser_tools.rs
@@ -498,34 +498,15 @@ pub fn calculate_fingerprint(bssid: &str,
     factors.push(caps.short_slot_time as u8);
     factors.push(caps.dsss_ofdm as u8);
 
-    // Supported rates.
-    if tagged_params.supported_rates.is_some() {
-        for rate in tagged_params.supported_rates.as_ref().unwrap() {
-            factors.extend(rate.to_le_bytes());
-        }
-    }
-
-    // Extended spported rates.
-    if tagged_params.extended_supported_rates.is_some() {
-        for rate in tagged_params.extended_supported_rates.as_ref().unwrap() {
-            factors.extend(rate.to_le_bytes());
-        }
-    }
-
-    // HT capabilities.
-    if tagged_params.ht_capabilities.is_some() {
-        factors.extend(tagged_params.ht_capabilities.as_ref().unwrap());
-    }
-
-    // Extended capabilities.
-    if tagged_params.extended_capabilities.is_some() {
-        factors.extend(tagged_params.extended_capabilities.as_ref().unwrap());
-    }
-
     // WPS
     factors.push(*has_wps as u8);
 
-    // Security / Encryption.
+    // Security / Encryption. Raw element bytes: the strong, stable
+    // discriminators. Supported rates, extended rates, HT and extended
+    // capabilities are deliberately excluded - they legitimately vary
+    // between beacon and probe-response frames of the same AP (probe
+    // responses may trim them), which would otherwise produce spurious
+    // fingerprint variants for a stable network.
     factors.extend(security);
 
     let hash = Sha256::digest(factors);


### PR DESCRIPTION
## Problem

The dot11 fingerprint hashed an element set that is **not stable across frame types or parse outcomes**:

1. **Parse hiccups**: `security_bytes` was only populated when the RSN element parsed cleanly (and PMF parsed). One frame with a hiccup (truncated element, unknown suite, PMF quirk) → different hash for the same AP.
2. **Frame-subtype variance**: the hash also included supported rates, extended rates, HT capabilities and extended capabilities — elements that probe responses may legitimately trim. Same AP, different hash depending on whether a beacon or a probe response was hashed first.

Both mechanisms made monitored networks alternate between fingerprints and fire spurious `DOT11_MONITOR_FINGERPRINT` alerts, each with a distinct hash (production data in #1506: stable beacon fingerprint across ~2,800/24h sightings, rare variants from probe responses and parse-failure frames).

## Fix (two commits)

1. **Raw security bytes always contribute** (`security_bytes.extend(data)` runs before parsing): parse-independent, so a hiccup cannot change the hash. The structured `security` list (suites/PMF) is still only populated on full parse success.
2. **Hash the invariant core only**: infrastructure type, capability bits, WPS flag, raw security bytes. Rates / extended rates / HT / extended capabilities are dropped — they legitimately vary between beacons and probe responses, and are weak discriminators (an evil twin replicates the config anyway).

With the hash subtype-stable, excluding probe responses from the report is no longer needed, so this supersedes the beacon-only approach in #1508 (closed).

## Testing

Deployed on a self-hosted tap + node: monitored networks show a single stable fingerprint; no variants and no fingerprint alerts across multiple monitored networks.

Fixes #1506
