### PR TITLE
tap: strip trailing FCS when radiotap flags say it is present

### DIFF
--- a/tap/src/protocols/parsers/dot11/dot11_header_parser.rs
+++ b/tap/src/protocols/parsers/dot11/dot11_header_parser.rs
@@ -73,6 +73,16 @@ pub fn parse(data: &Arc<Dot11RawFrame>) -> Result<(Dot11Frame, u32), Error> {
         None
     };
 
+    // Radiotap flags may indicate the capture includes the frame's trailing
+    // FCS (802.11-2020 §9.3.1: 4-octet CRC-32). Strip it before parsing:
+    // otherwise the tag walker reads the CRC bytes as spurious elements
+    // (e.g. fake "element 48" at the end of beacons), causing parse noise
+    // and false "RSN fail" warnings.
+    let fcs_len: usize = match &flags {
+        Some(f) if f.fcs_at_end && data.data.len() >= header_length + 4 => 4,
+        _ => 0,
+    };
+
     // Data Rate.
     let data_rate: Option<u32> = if present_flags.rate {
         let data_rate = match radiotap_buffer.take(1) {
@@ -225,7 +235,7 @@ pub fn parse(data: &Arc<Dot11RawFrame>) -> Result<(Dot11Frame, u32), Error> {
         antenna
     };
 
-    let payload = &data.data[header_length..data.data.len()];
+    let payload = &data.data[header_length..data.data.len() - fcs_len];
 
     if payload.len() < 2 {
         trace!("Payload too short.");


### PR DESCRIPTION
## Problem

The radiotap flags field has a dedicated bit for **"FCS at end"** (radiotap spec; 802.11-2020 §9.3.1 — every MAC frame ends with a 4-octet CRC-32). The parser already reads this bit into `RadiotapHeaderFlags.fcs_at_end`… but never honors it. Frames captured with the FCS included therefore keep **4 trailing CRC bytes in the payload**.

The dot11 tag walker then reads those CRC bytes as spurious elements. Production data (self-hosted tap, ath9k radio):

- ~**2.3% of beacons** of a stable AP gained fake trailing "elements" (ids 130/131/214/71 — literally CRC bytes), always exactly 4 trailing bytes
- Occasionally a CRC byte is `0x30`, forming a fake **"element 48"** → false `Could not parse RSN information` warnings
- Correlated with **fingerprint variance** on monitored networks: the fake tail elements polluted the parsed tag set, producing spurious `unexpected fingerprint` alerts (~0.5% of sightings, distinct hashes)

## Fix

When the `fcs_at_end` flag is set, strip the trailing 4 bytes before parsing (with a length guard).

## Testing

Deployed on the self-hosted tap. After the fix:

- **0/1,681** beacon sightings produced a fingerprint variant (was ~0.5%)
- **0** RSN-parse warnings (was ~1/hour)
- **0** fingerprint alerts (was ~1/hour)
- Beacon walks consume exactly the pre-FCS byte count; no more fake trailing elements

This likely also roots out the trigger behind #1507 (probe-request IE-walk OOB panic — short frames with FCS tails feeding a bad length byte into the walker); #1507 remains valid as bounds-checking hardening.
