### PR TITLE
tap/node: disco events - fix per-transmitter aggregation and report signal strength

### DIFF
--- a/src/main/java/app/nzyme/core/rest/resources/taps/reports/tables/dot11/Dot11DiscoTransmitterReport.java
+++ b/src/main/java/app/nzyme/core/rest/resources/taps/reports/tables/dot11/Dot11DiscoTransmitterReport.java
@@ -12,15 +12,24 @@ public abstract class Dot11DiscoTransmitterReport {
     public abstract String bssid();
     public abstract long sentFrames();
     public abstract Map<String, Long> receivers();
+    public abstract double signalStrengthAverage();
+    public abstract int signalStrengthMin();
+    public abstract int signalStrengthMax();
 
     @JsonCreator
     public static Dot11DiscoTransmitterReport create(@JsonProperty("bssid") String bssid,
                                                      @JsonProperty("sent_frames") long sentFrames,
-                                                     @JsonProperty("receivers") Map<String, Long> receivers) {
+                                                     @JsonProperty("receivers") Map<String, Long> receivers,
+                                                     @JsonProperty("signal_strength_average") double signalStrengthAverage,
+                                                     @JsonProperty("signal_strength_min") int signalStrengthMin,
+                                                     @JsonProperty("signal_strength_max") int signalStrengthMax) {
         return builder()
                 .bssid(bssid)
                 .sentFrames(sentFrames)
                 .receivers(receivers)
+                .signalStrengthAverage(signalStrengthAverage)
+                .signalStrengthMin(signalStrengthMin)
+                .signalStrengthMax(signalStrengthMax)
                 .build();
     }
 
@@ -35,6 +44,12 @@ public abstract class Dot11DiscoTransmitterReport {
         public abstract Builder sentFrames(long sentFrames);
 
         public abstract Builder receivers(Map<String, Long> receivers);
+
+        public abstract Builder signalStrengthAverage(double signalStrengthAverage);
+
+        public abstract Builder signalStrengthMin(int signalStrengthMin);
+
+        public abstract Builder signalStrengthMax(int signalStrengthMax);
 
         public abstract Dot11DiscoTransmitterReport build();
     }

--- a/src/main/java/app/nzyme/core/tables/dot11/Dot11Table.java
+++ b/src/main/java/app/nzyme/core/tables/dot11/Dot11Table.java
@@ -608,12 +608,17 @@ public class Dot11Table implements DataTable {
     private void writeDiscoReport(Handle handle, Tap tap, DateTime timestamp, Dot11.DiscoType discoType, Dot11DiscoTransmitterReport report) {
         long activityId = handle.createQuery(
                 "INSERT INTO dot11_disco_activity(tap_uuid, disco_type, bssid, sent_frames, " +
-                        "created_at) VALUES(:tap_uuid, :disco_type, :bssid, :sent_frames, :created_at) " +
+                        "signal_strength_average, signal_strength_min, signal_strength_max, created_at) " +
+                        "VALUES(:tap_uuid, :disco_type, :bssid, :sent_frames, " +
+                        ":signal_strength_average, :signal_strength_min, :signal_strength_max, :created_at) " +
                         "RETURNING id")
                 .bind("tap_uuid", tap.uuid())
                 .bind("disco_type", discoType.getNumber())
                 .bind("bssid", report.bssid())
                 .bind("sent_frames", report.sentFrames())
+                .bind("signal_strength_average", report.signalStrengthAverage())
+                .bind("signal_strength_min", report.signalStrengthMin())
+                .bind("signal_strength_max", report.signalStrengthMax())
                 .bind("created_at", timestamp)
                 .mapTo(Long.class)
                 .one();

--- a/tap/src/link/payloads.rs
+++ b/tap/src/link/payloads.rs
@@ -341,7 +341,10 @@ pub struct Dot11DiscoReport {
 pub struct DiscoTransmitterReport {
     pub bssid: String,
     pub sent_frames: u128,
-    pub receivers: HashMap<String, u128>
+    pub receivers: HashMap<String, u128>,
+    pub signal_strength_average: f64,
+    pub signal_strength_min: i32,
+    pub signal_strength_max: i32
 }
 
 #[derive(Serialize)]

--- a/tap/src/state/tables/dot11_table.rs
+++ b/tap/src/state/tables/dot11_table.rs
@@ -78,7 +78,8 @@ pub struct DiscoTable {
 pub struct DiscoTransmitter {
     pub bssid: String,
     pub sent_frames: u128,
-    pub receivers: HashMap<String, u128>
+    pub receivers: HashMap<String, u128>,
+    pub signal_strengths: Vec<i8>
 }
 
 impl Dot11Table {
@@ -408,18 +409,21 @@ impl Dot11Table {
     pub fn register_deauthentication_frame(&self, frame: Dot11DeauthenticationFrame) {
         self.register_disco_frame(frame.transmitter,
                                   frame.destination,
+                                  frame.header.antenna_signal,
                                   &self.disco.deauth);
     }
 
     pub fn register_disassociation_frame(&self, frame: Dot11DisassociationFrame) {
         self.register_disco_frame(frame.transmitter,
                                   frame.destination,
+                                  frame.header.antenna_signal,
                                   &self.disco.disassoc);
     }
 
     fn register_disco_frame(&self,
                             transmitter: String,
                             receiver: String,
+                            signal: Option<i8>,
                             table: &Mutex<HashMap<String, DiscoTransmitter>>) {
         match table.lock() {
             Ok(mut transmitters) => {
@@ -427,6 +431,7 @@ impl Dot11Table {
                     Some(transmitter) => {
                         // Existing transmitter.
                         transmitter.sent_frames += 1;
+                        transmitter.signal_strengths.push(signal.unwrap_or(0));
 
                         match transmitter.receivers.get_mut(&receiver.clone()) {
                             Some(destination) => { *destination += 1; },
@@ -439,11 +444,12 @@ impl Dot11Table {
                         receivers.insert(receiver.clone(), 1);
 
                         transmitters.insert(
-                            receiver.clone(),
+                            transmitter.clone(),
                             DiscoTransmitter {
                                 bssid: transmitter.clone(),
                                 sent_frames: 1,
-                                receivers
+                                receivers,
+                                signal_strengths: vec![signal.unwrap_or(0)]
                             }
                         );
                     }
@@ -742,12 +748,25 @@ impl Dot11Table {
         match table.lock() {
             Ok(deauth) => {
                 for (bssid, info) in &*deauth {
+                    let (avg, min, max) = if info.signal_strengths.is_empty() {
+                        (0.0_f64, 0_i32, 0_i32)
+                    } else {
+                        let sum: i64 = info.signal_strengths.iter().map(|&s| s as i64).sum();
+                        let avg = sum as f64 / info.signal_strengths.len() as f64;
+                        let min = *info.signal_strengths.iter().min().unwrap_or(&0);
+                        let max = *info.signal_strengths.iter().max().unwrap_or(&0);
+                        (avg, min as i32, max as i32)
+                    };
+
                     report.insert(
                         bssid.clone(),
                         DiscoTransmitterReport {
                             bssid: info.bssid.clone(),
                             sent_frames: info.sent_frames,
                             receivers: info.receivers.clone(),
+                            signal_strength_average: avg,
+                            signal_strength_min: min,
+                            signal_strength_max: max,
                         }
                     );
                 }


### PR DESCRIPTION
## Two related fixes to disco (deauth/disassoc) tracking

### 1. Aggregation bug — the map is keyed by receiver, not transmitter

`register_disco_frame` looks the map up by **transmitter** (`get_mut(&transmitter)`) but inserts new entries keyed by **receiver**:

```rust
transmitters.insert(receiver.clone(), DiscoTransmitter { bssid: transmitter.clone(), ... });
```

Consequences (all observed in production):
- `sent_frames` never accumulates — a repeated (transmitter, receiver) pair *replaces* its entry, resetting to 1
- One `dot11_disco_activity` row per **receiver** instead of one per **transmitter** — a burst of N deauths to N clients produced N rows with `sent_frames = 1` each
- The `receivers` map never aggregates multiple targets per transmitter
- The disco monitor's anomaly scoring operates on fragmented rows

Fix: key new entries by `transmitter`.

### 2. Signal strength never reported for disco events

The tap receives the antenna signal for every deauth/disassoc frame but only counts are stored, so deauth-source forensics is impossible retroactively. Report per-transmitter `signal_strength_average` / `signal_strength_min` / `signal_strength_max` (tap report fields + node model + `dot11_disco_activity` columns).

## Production verification

With both fixes deployed:
- Deauth bursts from neighbor routers collapse into single aggregated rows per transmitter (previously dozens of per-receiver rows)
- The reported deauth signal matches each transmitter's own beacon RSSI within a few dB — enabling the forensics use case (confirming the deauths are the APs' own client management, not a spoofing transmitter)

Fixes #1515
